### PR TITLE
build: fix building on MinGW

### DIFF
--- a/src/libANGLE/HandleAllocator.cpp
+++ b/src/libANGLE/HandleAllocator.cpp
@@ -10,6 +10,7 @@
 #include "libANGLE/HandleAllocator.h"
 
 #include <algorithm>
+#include <limits>
 
 #include "common/debug.h"
 


### PR DESCRIPTION
GCC complains about `std::numeric_limits` not in `std`, and indeed the `<limits>` header is not included anywhere in the dependency chain, so add it in order to allow compiling in MinGW.

This is part of a fix for https://github.com/solvespace/solvespace/issues/1570